### PR TITLE
Initial document symbol endpoint

### DIFF
--- a/src/msbuildls.LanguageServer/Extensions/LanguageServerOptionsExtensions.cs
+++ b/src/msbuildls.LanguageServer/Extensions/LanguageServerOptionsExtensions.cs
@@ -8,6 +8,7 @@ public static class LanguageServerOptionsExtensions
     public static LanguageServerOptions AddTextDocumentHandlers(this LanguageServerOptions options)
     {
         return options
-            .WithHandler<TextDocumentHandler>();
+            .WithHandler<TextDocumentHandler>()
+            .WithHandler<TextDocumentSymbolsHandler>();
     }
 }

--- a/src/msbuildls.LanguageServer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/msbuildls.LanguageServer/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddSymbolResolutionServices(this IServiceCollection services)
     {
         return services
-            .AddSingleton<ISymbolFactory, SymbolFactory>();
+            .AddSingleton<ISymbolFactory, SymbolFactory>()
+            .AddSingleton<ISymbolProvider, SymbolProvider>();
     }
 }

--- a/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
+++ b/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using msbuildls.LanguageServer.Symbols;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace msbuildls.LanguageServer.Handlers;
+
+internal class TextDocumentSymbolsHandler : DocumentSymbolHandlerBase
+{
+    private readonly ISymbolProvider _symbolProvider;
+
+    public TextDocumentSymbolsHandler(ISymbolProvider symbolProvider)
+    {
+        _symbolProvider = symbolProvider;
+    }
+    public override Task<SymbolInformationOrDocumentSymbolContainer?> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_symbolProvider.GetSymbolsForDocument(request.TextDocument.Uri.Path));
+    }
+
+    protected override DocumentSymbolRegistrationOptions CreateRegistrationOptions(DocumentSymbolCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new DocumentSymbolRegistrationOptions()
+        {
+            DocumentSelector = new TextDocumentSelector(
+                new TextDocumentFilter()
+                {
+                    Pattern = "{**/*.props,**/*.targets,**/*.*proj}"
+                }
+            )
+        };
+    }
+}

--- a/src/msbuildls.LanguageServer/Symbols/ISymbolProvider.cs
+++ b/src/msbuildls.LanguageServer/Symbols/ISymbolProvider.cs
@@ -1,0 +1,9 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace msbuildls.LanguageServer.Symbols;
+
+public interface ISymbolProvider
+{
+    SymbolInformationOrDocumentSymbolContainer? GetSymbolsForDocument(string fileName);
+    void AddOrUpdateDocumentSymbols(string fileName, DocumentSymbol document);
+}

--- a/src/msbuildls.LanguageServer/Symbols/SymbolFactory.cs
+++ b/src/msbuildls.LanguageServer/Symbols/SymbolFactory.cs
@@ -46,26 +46,37 @@ internal class SymbolFactory : ISymbolFactory
             }
         }
 
-        var lineInfo = (IXmlLineInfo)rootNode;
+        var range = MakeSymbolRange(rootNode);
         return new DocumentSymbol()
         {
             Name = rootNode.Name.LocalName,
             Children = new Container<DocumentSymbol>(childSymbols),
             Kind = (SymbolKind)MsBuildSymbolKind.Project,
-            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-                new Position(lineInfo.LineNumber, lineInfo.LinePosition),
-                new Position(lineInfo.LineNumber, lineInfo.LinePosition + rootNode.Name.LocalName.Length))
+            Range = range,
+            SelectionRange = range
         };
     }
 
     public DocumentSymbol MakePropertyFromNode(XElement propertyNode)
     {
-        var lineInfo = (IXmlLineInfo)propertyNode;
+        var range = MakeSymbolRange(propertyNode);
         return new DocumentSymbol()
         {
             Name = propertyNode.Name.LocalName,
-            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(new Position(lineInfo.LineNumber, lineInfo.LinePosition), new Position(lineInfo.LineNumber, lineInfo.LinePosition + propertyNode.Name.LocalName.Length)),
+            Range = range,
+            SelectionRange = range,
             Kind =  (SymbolKind)MsBuildSymbolKind.Property
         };
+    }
+
+    private Range MakeSymbolRange(XElement node)
+    {
+        var lineInfo = (IXmlLineInfo)node;
+        var offset = -1; // VSCode LSP client 0-indexes position values. If multiple client support is added, this will have to update if those clients have 1-indexed positions
+
+        return new Range(
+            new Position(lineInfo.LineNumber + offset, lineInfo.LinePosition + offset),
+            new Position(lineInfo.LineNumber + offset, lineInfo.LinePosition + node.Name.LocalName.Length + offset)
+        );
     }
 }

--- a/src/msbuildls.LanguageServer/Symbols/SymbolProvider.cs
+++ b/src/msbuildls.LanguageServer/Symbols/SymbolProvider.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace msbuildls.LanguageServer.Symbols;
+
+internal class SymbolProvider : ISymbolProvider
+{
+    private readonly ConcurrentDictionary<string, DocumentSymbol> _documentSymbolStore;
+
+    public SymbolProvider()
+    {
+        _documentSymbolStore = new ConcurrentDictionary<string, DocumentSymbol>();
+    }
+
+    public void AddOrUpdateDocumentSymbols(string fileName, DocumentSymbol document)
+    {
+        _documentSymbolStore.AddOrUpdate(fileName, document, (name, oldDocument) => document);
+    }
+
+    public SymbolInformationOrDocumentSymbolContainer? GetSymbolsForDocument(string fileName)
+    {
+        if (_documentSymbolStore.TryGetValue(fileName, out var documentSymbol))
+        {
+            return new SymbolInformationOrDocumentSymbolContainer(documentSymbol);
+        }
+        return null;
+    }
+}

--- a/test/msbuildls.Tests/Handlers/TextDocumentHandlerTests.cs
+++ b/test/msbuildls.Tests/Handlers/TextDocumentHandlerTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using msbuildls.LanguageServer.Handlers;
+using msbuildls.LanguageServer.Symbols;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace msbuildls.Tests.Handlers;
+
+public class TextDocumentHandlerTests
+{
+    [Fact]
+    public async Task OpenDocumentAddsSymbolsToProviderAsync()
+    {
+        var symbolName = "Project";
+        var openDocParams = new DidOpenTextDocumentParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Text = "<Project></Project>",
+                Uri = new Uri(@"C:\test.targets")
+            }
+        };
+        var expectedXmlNode = XElement.Parse(openDocParams.TextDocument.Text, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+        var mockSymbolFactory = new Mock<ISymbolFactory>();
+        mockSymbolFactory
+            .Setup(factory => factory.MakeDocumentSymbols(It.IsAny<XElement>()))
+            .Returns(new DocumentSymbol() { Name = symbolName })
+            .Callback<XElement>((inputNode) =>
+            {
+                Assert.NotNull(inputNode);
+                Assert.Equal(expectedXmlNode.Name.LocalName, inputNode.Name.LocalName);
+            });
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.AddOrUpdateDocumentSymbols(It.IsAny<string>(), It.IsAny<DocumentSymbol>()))
+            .Callback<string, DocumentSymbol>((docName, docSymbol) =>
+            {
+                Assert.NotNull(docSymbol);
+                Assert.Equal(openDocParams.TextDocument.Uri.Path, docName);
+                Assert.Equal(symbolName, docSymbol.Name);
+            });
+
+        var textDocumentHandler = new TextDocumentHandler(
+            NullLogger<TextDocumentHandler>.Instance,
+            mockSymbolFactory.Object,
+            mockSymbolProvider.Object
+        );
+
+        await textDocumentHandler.Handle(openDocParams, new CancellationToken());
+
+        mockSymbolFactory.Verify(factory => factory.MakeDocumentSymbols(It.IsAny<XElement>()), Times.Once());
+        mockSymbolProvider.Verify(provider => provider.AddOrUpdateDocumentSymbols(It.IsAny<string>(), It.IsAny<DocumentSymbol>()), Times.Once());
+    }
+}

--- a/test/msbuildls.Tests/Handlers/TextDocumentSymbolsHandler.cs
+++ b/test/msbuildls.Tests/Handlers/TextDocumentSymbolsHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using msbuildls.LanguageServer.Handlers;
+using msbuildls.LanguageServer.Symbols;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace msbuildls.Tests.Handlers;
+
+public class TextDocumentSymbolsHandlerTests
+{
+    [Fact]
+    public async Task SymbolsFromSymbolProviderAsync()
+    {
+        var docSymbolParams = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\test.targets")
+            }
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetSymbolsForDocument(It.IsAny<string>()))
+            .Returns(default(SymbolInformationOrDocumentSymbolContainer))
+            .Callback<string>(docPath => Assert.Equal(docSymbolParams.TextDocument.Uri.Path, docPath));
+
+        var handler = new TextDocumentSymbolsHandler(mockSymbolProvider.Object);
+
+        await handler.Handle(docSymbolParams, new CancellationToken());
+
+        mockSymbolProvider.Verify(provider => provider.GetSymbolsForDocument(It.IsAny<string>()), Times.Once());
+    }
+}

--- a/test/msbuildls.Tests/SymbolFactoryTests.cs
+++ b/test/msbuildls.Tests/SymbolFactoryTests.cs
@@ -13,8 +13,20 @@ public class SymbolFactoryTests
     [Fact]
     public void CanMakePropertySymbol()
     {
-        var startLine = 3;
-        var startLineCharacter = 10;
+        var startLine = 2;
+        var startChar = 9;
+        var name = "TestProperty";
+        var expectedSymbol = new DocumentSymbol()
+        {
+            Name = name,
+            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+            Range = new Range(
+                startLine : startLine,
+                startCharacter: startChar,
+                endLine: startLine,
+                endCharacter: startChar + name.Length
+            )
+        };
 
         var symbolFactory = new SymbolFactory();
 
@@ -23,25 +35,25 @@ public class SymbolFactoryTests
 
         var propertySymbol = symbolFactory.MakePropertyFromNode(propertyNode);
 
-        Assert.Equal("TestProperty", propertySymbol.Name);
-        Assert.Equal(startLine, propertySymbol.Range.Start.Line);
-        Assert.Equal(startLineCharacter, propertySymbol.Range.Start.Character);
-        Assert.Equal(startLine, propertySymbol.Range.End.Line);
-        Assert.Equal(startLineCharacter + propertySymbol.Name.Length, propertySymbol.Range.End.Character);
-        Assert.Equal((SymbolKind)MsBuildSymbolKind.Property, propertySymbol.Kind);
+        Assert.Equal(expectedSymbol.Name, propertySymbol.Name);
+        Assert.Equal(expectedSymbol.Range.Start.Line, propertySymbol.Range.Start.Line);
+        Assert.Equal(expectedSymbol.Range.Start.Character, propertySymbol.Range.Start.Character);
+        Assert.Equal(expectedSymbol.Range.End.Line, propertySymbol.Range.End.Line);
+        Assert.Equal(expectedSymbol.Range.End.Character, propertySymbol.Range.End.Character);
+        Assert.Equal(expectedSymbol.Kind, propertySymbol.Kind);
     }
 
     [Fact]
     public void CanMakeProjectSymbol()
     {
         var name = KnownMsBuildNodes.Project;
-        var startLine = 1;
-        var startChar = 2;
+        var startLine = 0;
+        var startChar = 1;
         var expectedSymbol = new DocumentSymbol()
         {
             Name = name,
             Kind = (SymbolKind)MsBuildSymbolKind.Project,
-            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+            Range = new Range(
                 startLine: startLine,
                 startCharacter: startChar,
                 endLine: startLine,

--- a/test/msbuildls.Tests/Symbols/SymbolProviderTests.cs
+++ b/test/msbuildls.Tests/Symbols/SymbolProviderTests.cs
@@ -1,0 +1,60 @@
+using msbuildls.LanguageServer.Symbols;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace msbuildls.Tests.Symbols;
+
+public class SymbolProviderTests
+{
+    [Fact]
+    public void CanGetSymbolsForFile()
+    {
+        var symbolProvider = new SymbolProvider();
+        var docName = "test.targets";
+        var expectedSymbol = new DocumentSymbol()
+        {
+            Name = "TestSymbol"
+        };
+
+        symbolProvider.AddOrUpdateDocumentSymbols(docName, expectedSymbol);
+        var docSymbols = symbolProvider.GetSymbolsForDocument(docName);
+
+        Assert.NotNull(docSymbols);
+        var docSymbol = Assert.Single(docSymbols);
+        Assert.Equal(expectedSymbol.Name, docSymbol?.DocumentSymbol?.Name);
+    }
+
+    [Fact]
+    public void CanGetUpdatedSymbolsForFile()
+    {
+        var symbolProvider = new SymbolProvider();
+        var docName = "test.targets";
+        var firstSymbol = new DocumentSymbol()
+        {
+            Name = "TestSymbol"
+        };
+        var expectedSymbol = new DocumentSymbol()
+        {
+            Name = "TestSymbol2"
+        };
+
+        symbolProvider.AddOrUpdateDocumentSymbols(docName, firstSymbol);
+        symbolProvider.AddOrUpdateDocumentSymbols(docName, expectedSymbol);
+
+        var docSymbols = symbolProvider.GetSymbolsForDocument(docName);
+
+        Assert.NotNull(docSymbols);
+        var docSymbol = Assert.Single(docSymbols);
+        Assert.Equal(expectedSymbol.Name, docSymbol?.DocumentSymbol?.Name);
+    }
+
+    [Fact]
+    public void NullSymbolForFileNotFound()
+    {
+        var symbolProvider = new SymbolProvider();
+
+        var docSymbols = symbolProvider.GetSymbolsForDocument("DoesNotExist.targets");
+
+        Assert.Null(docSymbols);
+    }
+}

--- a/test/msbuildls.Tests/msbuildls.Tests.csproj
+++ b/test/msbuildls.Tests/msbuildls.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Add initial document symbol endpoint handling for single file symbols. Added initial symbol provider implementation and hooked up the existing document open handling to push symbols to the provider. Add testing for new services and handlers.