### PR TITLE
Initial target symbol handling

### DIFF
--- a/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
+++ b/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
@@ -59,16 +59,67 @@ internal class TextDocumentSymbolsHandler : DocumentSymbolHandlerBase
         };
     }
 
+    // This is going to have to change again when the go to definition feature is implemented...
     private SymbolInformationOrDocumentSymbolContainer? FilterDuplicateSymbols(SymbolInformationOrDocumentSymbolContainer? rawSymbols)
     {
         if (rawSymbols is null)
         {
             return null;
         }
-        // This works for now with project-scoped properties. Will need updates for targets.
-        // Property "original definition" is the first use of the property.
-        // Target "definition" for execution is the last definition of the target
-        var hashedSymbols = rawSymbols.DistinctBy(symbol => symbol.DocumentSymbol?.Name);
-        return SymbolInformationOrDocumentSymbolContainer.From(hashedSymbols);
+
+        var knownSymbols = rawSymbols
+            .Where(symbol => symbol.DocumentSymbol!.Kind == (SymbolKind)MsBuildSymbolKind.Property)
+            .GroupBy(symbol => new SymbolKey(symbol.DocumentSymbol!.Name, symbol.DocumentSymbol.Kind))
+            .ToDictionary(group => group.Key, group => group.OrderBy(symbol => symbol.DocumentSymbol!.Range.Start).First());
+
+        // Flatten targets and nested symbols
+        foreach (var target in rawSymbols.Where(symbol => symbol.DocumentSymbol!.Kind == (SymbolKind)MsBuildSymbolKind.Target))
+        {
+            var targetKey = new SymbolKey(target.DocumentSymbol!.Name, target.DocumentSymbol.Kind);
+            // Don't bother with redefinitions of targets for now.
+            // Technically the last definition of a target after evaluation is the one that gets executed if the target is called, which complicates the decision making about which nested symbols are populated.
+            if (knownSymbols.ContainsKey(targetKey))
+            {
+                continue;
+            }
+
+            // Don't need to add nested symbols if they don't exist
+            if (target.DocumentSymbol.Children is null)
+            {
+                knownSymbols.Add(targetKey, target);
+                continue;
+            }
+
+            // Have to remake the symbol because the properties are init-only sets and we need to flatten the symbol hierarchy (no child symbols)
+            var newTarget = new DocumentSymbol()
+            {
+                Name = target.DocumentSymbol.Name,
+                Kind = target.DocumentSymbol.Kind,
+                Range = target.DocumentSymbol.Range,
+                SelectionRange = target.DocumentSymbol.SelectionRange
+            };
+            knownSymbols.Add(targetKey, newTarget);
+
+            var nestedSymbols = target.DocumentSymbol.Children
+                .Where(nestedSymbol => nestedSymbol.Kind == (SymbolKind)MsBuildSymbolKind.Property)
+                .GroupBy(nestedSymbol => new SymbolKey(nestedSymbol.Name, nestedSymbol.Kind));
+
+            // Add the nested symbol to the known symbols collection if it's unknown
+            foreach (var symbolGroup in nestedSymbols)
+            {
+                if (knownSymbols.ContainsKey(symbolGroup.Key))
+                {
+                    continue;
+                }
+
+                var nestedSymbol = symbolGroup.OrderBy(symbol => symbol.Range.Start).First();
+
+                knownSymbols.Add(symbolGroup.Key, nestedSymbol);
+            }
+        }
+
+        return SymbolInformationOrDocumentSymbolContainer.From(knownSymbols.Values);
     }
+
+    private record SymbolKey(string Name, SymbolKind Kind);
 }

--- a/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
+++ b/src/msbuildls.LanguageServer/Handlers/TextDocumentSymbolsHandler.cs
@@ -59,7 +59,6 @@ internal class TextDocumentSymbolsHandler : DocumentSymbolHandlerBase
         };
     }
 
-    // This is going to have to change again when the go to definition feature is implemented...
     private SymbolInformationOrDocumentSymbolContainer? FilterDuplicateSymbols(SymbolInformationOrDocumentSymbolContainer? rawSymbols)
     {
         if (rawSymbols is null)

--- a/src/msbuildls.LanguageServer/Symbols/MSBuild/Project.cs
+++ b/src/msbuildls.LanguageServer/Symbols/MSBuild/Project.cs
@@ -9,4 +9,7 @@ public class Project
 {
     [XmlElement(nameof(PropertyGroup))]
     public PropertyGroup[]? PropertyGroups { get; set; }
+
+    [XmlElement(nameof(Target))]
+    public Target[]? Targets { get; set; }
 }

--- a/src/msbuildls.LanguageServer/Symbols/MSBuild/PropertyGroup.cs
+++ b/src/msbuildls.LanguageServer/Symbols/MSBuild/PropertyGroup.cs
@@ -1,9 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace msbuildls.LanguageServer.Symbols.MSBuild;
 
-public class PropertyGroup
+public class PropertyGroup : IXmlSerializable
 {
-    [XmlAnyElement] // Must be an any element because otherwise the (de)serializer thinks the property name is the object type
     public Property[]? Properties { get; set; }
+
+    public XmlSchema? GetSchema()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void ReadXml(XmlReader reader)
+    {
+        reader.ReadStartElement();
+
+        var properties = new List<Property>();
+        while (reader.NodeType != XmlNodeType.EndElement)
+        {
+            var property = new Property();
+            property.ReadXml(reader);
+            properties.Add(property);
+        }
+
+        if (properties.Any())
+        {
+            Properties = [.. properties];
+        }
+
+        reader.ReadEndElement();
+    }
+
+    public void WriteXml(XmlWriter writer)
+    {
+        throw new System.NotImplementedException();
+    }
 }

--- a/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
+++ b/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
@@ -1,0 +1,12 @@
+using System.Xml.Serialization;
+
+namespace msbuildls.LanguageServer.Symbols.MSBuild;
+
+public class Target
+{
+    [XmlAttribute]
+    public string Name { get; set; } = string.Empty;
+
+    [XmlElement(nameof(PropertyGroup))]
+    public PropertyGroup[]? PropertyGroups { get; set; }
+}

--- a/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
+++ b/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
@@ -39,6 +39,10 @@ public class Target : IXmlSerializable
                 propGroup.ReadXml(reader);
                 propGroups.Add(propGroup);
             }
+            else // All unhandled nodes get skipped
+            {
+                reader.Read();
+            }
         }
 
         if (propGroups.Any())

--- a/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
+++ b/src/msbuildls.LanguageServer/Symbols/MSBuild/Target.cs
@@ -1,12 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Schema;
 using System.Xml.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace msbuildls.LanguageServer.Symbols.MSBuild;
 
-public class Target
+public class Target : IXmlSerializable
 {
     [XmlAttribute]
     public string Name { get; set; } = string.Empty;
 
     [XmlElement(nameof(PropertyGroup))]
     public PropertyGroup[]? PropertyGroups { get; set; }
+    public Position StartPosition { get; set; } = new Position(1, 1);
+    public Position EndPosition { get; set; } = new Position(1,1);
+
+    public XmlSchema? GetSchema()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void ReadXml(XmlReader reader)
+    {
+        var startLineInfo = (IXmlLineInfo)reader;
+        StartPosition = new Position(startLineInfo.LineNumber, startLineInfo.LinePosition);
+
+        Name = reader.GetAttribute(nameof(Name)) ?? string.Empty;
+        reader.ReadStartElement();
+
+        var propGroups = new List<PropertyGroup>();
+        while (reader.NodeType != XmlNodeType.EndElement)
+        {
+            if (reader.LocalName == nameof(PropertyGroup))
+            {
+                var propGroup = new PropertyGroup();
+                propGroup.ReadXml(reader);
+                propGroups.Add(propGroup);
+            }
+        }
+
+        if (propGroups.Any())
+        {
+            PropertyGroups = [.. propGroups];
+        }
+
+        var endLineInfo = (IXmlLineInfo)reader;
+        EndPosition = new Position(endLineInfo.LineNumber, endLineInfo.LinePosition + nameof(Target).Length);
+        reader.ReadEndElement();
+    }
+
+    public void WriteXml(XmlWriter writer)
+    {
+        throw new System.NotImplementedException();
+    }
 }

--- a/test/msbuildls.Tests/Handlers/TextDocumentSymbolsHandlerTests.cs
+++ b/test/msbuildls.Tests/Handlers/TextDocumentSymbolsHandlerTests.cs
@@ -204,4 +204,475 @@ public class TextDocumentSymbolsHandlerTests
         Assert.Equal(property1.Name, symbol.DocumentSymbol.Name);
         Assert.Equal(property1.StartLine, symbol.DocumentSymbol.Range.Start.Line);
     }
+
+    [Fact]
+    public async Task FilterProjectPropertiesFromTargetSymbolsAsync()
+    {
+        var logger = NullLogger<TextDocumentSymbolsHandler>.Instance;
+
+        var projectProperty = new Property()
+        {
+            Name = "TestProperty",
+            StartLine = 3,
+            StartChar = 10,
+            EndLine = 3,
+            EndChar = 40
+        };
+        var targetProperty = new Property()
+        {
+            Name = projectProperty.Name, // Must have the same name as the project-level property for a valid test
+            StartLine = 7,
+            StartChar = 14,
+            EndLine = 7,
+            EndChar = 44
+        };
+        var target = new Target()
+        {
+            Name = "TestTarget",
+            StartPosition = new Position(5, 5),
+            EndPosition = new Position(9, 5),
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties = [ targetProperty ]
+                }
+            ]
+        };
+        var fileSymbols = new Project()
+        {
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties =
+                    [
+                        projectProperty
+                    ]
+                }
+            ],
+            Targets = [ target ]
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetFileSymbols(It.IsAny<string>()))
+            .Returns(fileSymbols);
+
+        var symbolFactory = new Mock<ISymbolFactory>();
+        symbolFactory
+            .Setup(factory => factory.SymbolsForFile(It.IsAny<Project>()))
+            .Returns(SymbolInformationOrDocumentSymbolContainer.From(new[]
+            {
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = projectProperty.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(projectProperty.StartLine, projectProperty.StartChar, projectProperty.EndLine, projectProperty.EndChar),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(projectProperty.StartLine, projectProperty.StartChar, projectProperty.StartLine, projectProperty.StartChar + projectProperty.Name.Length)
+                }),
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.StartPosition),
+                    Children = new[]
+                    {
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.EndLine, targetProperty.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.StartLine, targetProperty.StartChar + targetProperty.Name.Length)
+                        }
+                    }
+                })
+            }));
+
+        var handler = new TextDocumentSymbolsHandler(logger, symbolFactory.Object, mockSymbolProvider.Object);
+        var request = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\SomeFile.targets")
+            }
+        };
+
+        var result = await handler.Handle(request, new CancellationToken());
+
+        Assert.NotNull(result);
+        var foundProperty = Assert.Single(result, symbol => symbol.DocumentSymbol?.Name == projectProperty.Name);
+        Assert.NotNull(foundProperty.DocumentSymbol);
+        Assert.Equal(projectProperty.StartLine, foundProperty.DocumentSymbol.Range.Start.Line); // Ensure we find the symbol at the correct line, indicating we filtered out the reference in the target
+    }
+
+    [Fact]
+    public async Task DoNotFilterExclusiveTargetPropertyAsync()
+    {
+        var logger = NullLogger<TextDocumentSymbolsHandler>.Instance;
+
+        var projectProperty = new Property()
+        {
+            Name = "TestProperty",
+            StartLine = 3,
+            StartChar = 10,
+            EndLine = 3,
+            EndChar = 40
+        };
+        var targetProperty = new Property()
+        {
+            Name = "TargetProperty", // Must have a different name as the project-level property for a valid test
+            StartLine = 7,
+            StartChar = 14,
+            EndLine = 7,
+            EndChar = 44
+        };
+        var target = new Target()
+        {
+            Name = "TestTarget",
+            StartPosition = new Position(5, 5),
+            EndPosition = new Position(9, 5),
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties = [ targetProperty ]
+                }
+            ]
+        };
+        var fileSymbols = new Project()
+        {
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties =[ projectProperty ]
+                }
+            ],
+            Targets = [ target ]
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetFileSymbols(It.IsAny<string>()))
+            .Returns(fileSymbols);
+
+        var symbolFactory = new Mock<ISymbolFactory>();
+        symbolFactory
+            .Setup(factory => factory.SymbolsForFile(It.IsAny<Project>()))
+            .Returns(SymbolInformationOrDocumentSymbolContainer.From(new[]
+            {
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = projectProperty.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(projectProperty.StartLine, projectProperty.StartChar, projectProperty.EndLine, projectProperty.EndChar),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(projectProperty.StartLine, projectProperty.StartChar, projectProperty.StartLine, projectProperty.StartChar + projectProperty.Name.Length)
+                }),
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.StartPosition),
+                    Children = new[]
+                    {
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.EndLine, targetProperty.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.StartLine, targetProperty.StartChar + targetProperty.Name.Length)
+                        }
+                    }
+                })
+            }));
+
+        var handler = new TextDocumentSymbolsHandler(logger, symbolFactory.Object, mockSymbolProvider.Object);
+        var request = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\SomeFile.targets")
+            }
+        };
+
+        var result = await handler.Handle(request, new CancellationToken());
+
+        Assert.NotNull(result);
+        var foundProperty = Assert.Single(result, symbol => symbol.DocumentSymbol?.Name == targetProperty.Name);
+    }
+
+    [Fact]
+    public async Task FilterTargetPropertyReferenceOnSameTargetAsync()
+    {
+        var logger = NullLogger<TextDocumentSymbolsHandler>.Instance;
+
+        var targetProperty = new Property()
+        {
+            Name = "TestProperty",
+            StartLine = 7,
+            StartChar = 14,
+            EndLine = 7,
+            EndChar = 44
+        };
+        var targetProperty2 = new Property()
+        {
+            Name = targetProperty.Name,
+            StartLine = targetProperty.StartLine + 1,
+            StartChar = targetProperty.StartChar,
+            EndLine = targetProperty.StartLine + 1,
+            EndChar = targetProperty.EndChar
+        };
+        var target = new Target()
+        {
+            Name = "TestTarget",
+            StartPosition = new Position(5, 5),
+            EndPosition = new Position(9, 5),
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties = [ targetProperty, targetProperty2 ]
+                }
+            ]
+        };
+        var fileSymbols = new Project()
+        {
+            Targets = [ target ]
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetFileSymbols(It.IsAny<string>()))
+            .Returns(fileSymbols);
+
+        var symbolFactory = new Mock<ISymbolFactory>();
+        symbolFactory
+            .Setup(factory => factory.SymbolsForFile(It.IsAny<Project>()))
+            .Returns(SymbolInformationOrDocumentSymbolContainer.From(new[]
+            {
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.StartPosition),
+                    Children = new[]
+                    {
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.EndLine, targetProperty.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty.StartLine, targetProperty.StartChar, targetProperty.StartLine, targetProperty.StartChar + targetProperty.Name.Length)
+                        },
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty2.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty2.StartLine, targetProperty2.StartChar, targetProperty2.EndLine, targetProperty2.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty2.StartLine, targetProperty2.StartChar, targetProperty2.StartLine, targetProperty2.StartChar + targetProperty2.Name.Length)
+                        }
+                    }
+                })
+            }));
+
+        var handler = new TextDocumentSymbolsHandler(logger, symbolFactory.Object, mockSymbolProvider.Object);
+        var request = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\SomeFile.targets")
+            }
+        };
+
+        var result = await handler.Handle(request, new CancellationToken());
+
+        Assert.NotNull(result);
+        var foundProperty = Assert.Single(result, symbol => symbol.DocumentSymbol?.Name == targetProperty.Name);
+        Assert.NotNull(foundProperty.DocumentSymbol);
+        Assert.Equal(targetProperty.StartLine, foundProperty.DocumentSymbol.Range.Start.Line); // Ensure we find the symbol at the correct line, indicating we filtered out the second reference in the target
+    }
+
+    [Fact]
+    public async Task FilterDuplicateTargetPropertyOnSeparateTargetAsync()
+    {
+        var logger = NullLogger<TextDocumentSymbolsHandler>.Instance;
+
+        var targetProperty1 = new Property()
+        {
+            Name = "TestProperty",
+            StartLine = 7,
+            StartChar = 14,
+            EndLine = 7,
+            EndChar = 44
+        };
+        var target1 = new Target()
+        {
+            Name = "TestTarget",
+            StartPosition = new Position(5, 5),
+            EndPosition = new Position(9, 5),
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties = [ targetProperty1 ]
+                }
+            ]
+        };
+        var targetProperty2 = new Property()
+        {
+            Name = targetProperty1.Name, // Must have the same name as the first target property for a valid test
+            StartLine = 12,
+            StartChar = 14,
+            EndLine = 12,
+            EndChar = 44
+        };
+        var target2 = new Target()
+        {
+            Name = "OtherTarget",
+            StartPosition = new Position(10, 5),
+            EndPosition = new Position(14, 5),
+            PropertyGroups =
+            [
+                new PropertyGroup()
+                {
+                    Properties = [ targetProperty2 ]
+                }
+            ]
+        };
+        var fileSymbols = new Project()
+        {
+            Targets = [ target1 ]
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetFileSymbols(It.IsAny<string>()))
+            .Returns(fileSymbols);
+
+        var symbolFactory = new Mock<ISymbolFactory>();
+        symbolFactory
+            .Setup(factory => factory.SymbolsForFile(It.IsAny<Project>()))
+            .Returns(SymbolInformationOrDocumentSymbolContainer.From(new[]
+            {
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target1.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target1.StartPosition, target1.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target1.StartPosition, target1.StartPosition),
+                    Children = new[]
+                    {
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty1.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty1.StartLine, targetProperty1.StartChar, targetProperty1.EndLine, targetProperty1.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty1.StartLine, targetProperty1.StartChar, targetProperty1.StartLine, targetProperty1.StartChar + targetProperty1.Name.Length)
+                        }
+                    }
+                }),
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target2.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target2.StartPosition, target2.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target2.StartPosition, target2.StartPosition),
+                    Children = new[]
+                    {
+                        new DocumentSymbol()
+                        {
+                            Name = targetProperty2.Name,
+                            Kind = (SymbolKind)MsBuildSymbolKind.Property,
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty2.StartLine, targetProperty2.StartChar, targetProperty2.EndLine, targetProperty2.EndChar),
+                            SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(targetProperty2.StartLine, targetProperty2.StartChar, targetProperty2.StartLine, targetProperty2.StartChar + targetProperty2.Name.Length)
+                        }
+                    }
+                })
+            }));
+
+        var handler = new TextDocumentSymbolsHandler(logger, symbolFactory.Object, mockSymbolProvider.Object);
+        var request = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\SomeFile.targets")
+            }
+        };
+
+        var result = await handler.Handle(request, new CancellationToken());
+
+        Assert.NotNull(result);
+        var foundProperty = Assert.Single(result, symbol => symbol.DocumentSymbol?.Name == targetProperty1.Name);
+        Assert.NotNull(foundProperty.DocumentSymbol);
+        Assert.Equal(targetProperty1.StartLine, foundProperty.DocumentSymbol.Range.Start.Line); // Ensure we find the symbol at the correct line, indicating we filtered out the reference in the second target
+    }
+
+    [Fact]
+    public async Task FilterTargetRedefinitionFromSameFileAsync()
+    {
+        var logger = NullLogger<TextDocumentSymbolsHandler>.Instance;
+
+        var target = new Target()
+        {
+            Name = "TestTarget",
+            StartPosition = new Position(2, 5),
+            EndPosition = new Position(3, 5)
+        };
+        var redefinedTarget = new Target()
+        {
+            Name = target.Name,
+            StartPosition = new Position(4, 5),
+            EndPosition = new Position(6, 5)
+        };
+        var fileSymbols = new Project()
+        {
+            Targets = [ target, redefinedTarget ]
+        };
+
+        var mockSymbolProvider = new Mock<ISymbolProvider>();
+        mockSymbolProvider
+            .Setup(provider => provider.GetFileSymbols(It.IsAny<string>()))
+            .Returns(fileSymbols);
+
+        var symbolFactory = new Mock<ISymbolFactory>();
+        symbolFactory
+            .Setup(factory => factory.SymbolsForFile(It.IsAny<Project>()))
+            .Returns(SymbolInformationOrDocumentSymbolContainer.From(new[]
+            {
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = target.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(target.StartPosition, target.StartPosition)
+                }),
+                SymbolInformationOrDocumentSymbol.Create(new DocumentSymbol()
+                {
+                    Name = redefinedTarget.Name,
+                    Kind = (SymbolKind)MsBuildSymbolKind.Target,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(redefinedTarget.StartPosition, redefinedTarget.EndPosition),
+                    SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(redefinedTarget.StartPosition, redefinedTarget.StartPosition)
+                }),
+            }));
+
+        var handler = new TextDocumentSymbolsHandler(logger, symbolFactory.Object, mockSymbolProvider.Object);
+        var request = new DocumentSymbolParams()
+        {
+            TextDocument = new TextDocumentItem()
+            {
+                Uri = new Uri(@"C:\SomeFile.targets")
+            }
+        };
+
+        var result = await handler.Handle(request, new CancellationToken());
+
+        Assert.NotNull(result);
+        var foundTarget = Assert.Single(result, symbol => symbol.DocumentSymbol?.Name == target.Name);
+        Assert.NotNull(foundTarget.DocumentSymbol);
+        Assert.Equal(target.StartPosition.Line, foundTarget.DocumentSymbol.Range.Start.Line); // Ensure we find the symbol at the correct line, indicating we filtered out the redefinition
+    }
 }

--- a/test/msbuildls.Tests/Symbols/SymbolFactoryTests.cs
+++ b/test/msbuildls.Tests/Symbols/SymbolFactoryTests.cs
@@ -179,4 +179,47 @@ public class SymbolFactoryTests
         var propGroup = Assert.Single(fileSymbols.PropertyGroups);
         Assert.Null(propGroup.Properties);
     }
+
+    [Fact]
+    public void CanDeserializeTarget()
+    {
+        var symbolFactory = new SymbolFactory(NullLogger<ISymbolFactory>.Instance);
+        var testFilePath = GetFullyQualifiedTestDataFilePath("target.targets");
+
+        var textDocumentItem = new TextDocumentItem()
+        {
+            Uri = new Uri(testFilePath),
+            Text = File.ReadAllText(testFilePath)
+        };
+
+        var fileSymbols = symbolFactory.ParseDocument(textDocumentItem);
+        Assert.NotNull(fileSymbols);
+        Assert.NotNull(fileSymbols.Targets);
+        var target = Assert.Single(fileSymbols.Targets);
+        Assert.Equal("TestTarget", target.Name);
+    }
+
+    [Fact]
+    public void CanDeserializePropertyOnTarget()
+    {
+        var symbolFactory = new SymbolFactory(NullLogger<ISymbolFactory>.Instance);
+        var testFilePath = GetFullyQualifiedTestDataFilePath("target.targets");
+
+        var textDocumentItem = new TextDocumentItem()
+        {
+            Uri = new Uri(testFilePath),
+            Text = File.ReadAllText(testFilePath)
+        };
+
+        var fileSymbols = symbolFactory.ParseDocument(textDocumentItem);
+        Assert.NotNull(fileSymbols);
+        Assert.NotNull(fileSymbols.Targets);
+        var target = Assert.Single(fileSymbols.Targets);
+        Assert.NotNull(target.PropertyGroups);
+        var targetPropGroup = Assert.Single(target.PropertyGroups);
+        Assert.NotNull(targetPropGroup.Properties);
+        var targetProperty = Assert.Single(targetPropGroup.Properties);
+        Assert.Equal("TargetProperty", targetProperty.Name);
+        /// Property deserialization fully tested in <see cref="CanParsePropertiesOnProjectNode"/>
+    }
 }

--- a/test/msbuildls.Tests/Symbols/SymbolFactoryTests.cs
+++ b/test/msbuildls.Tests/Symbols/SymbolFactoryTests.cs
@@ -197,13 +197,18 @@ public class SymbolFactoryTests
         Assert.NotNull(fileSymbols.Targets);
         var target = Assert.Single(fileSymbols.Targets);
         Assert.Equal("TestTarget", target.Name);
+        Assert.Equal(2, target.StartPosition.Line);
+        Assert.Equal(6, target.StartPosition.Character);
+        Assert.Equal(3, target.EndPosition.Line);
+        Assert.Equal(13, target.EndPosition.Character);
+        Assert.Null(target.PropertyGroups);
     }
 
     [Fact]
     public void CanDeserializePropertyOnTarget()
     {
         var symbolFactory = new SymbolFactory(NullLogger<ISymbolFactory>.Instance);
-        var testFilePath = GetFullyQualifiedTestDataFilePath("target.targets");
+        var testFilePath = GetFullyQualifiedTestDataFilePath("targetWithProperty.targets");
 
         var textDocumentItem = new TextDocumentItem()
         {

--- a/test/testData/SymbolFactoryTests/target.targets
+++ b/test/testData/SymbolFactoryTests/target.targets
@@ -1,7 +1,4 @@
 <Project>
     <Target Name="TestTarget">
-        <PropertyGroup>
-            <TargetProperty>testvalue</TargetProperty>
-        </PropertyGroup>
     </Target>
 </Project>

--- a/test/testData/SymbolFactoryTests/target.targets
+++ b/test/testData/SymbolFactoryTests/target.targets
@@ -1,0 +1,7 @@
+<Project>
+    <Target Name="TestTarget">
+        <PropertyGroup>
+            <TargetProperty>testvalue</TargetProperty>
+        </PropertyGroup>
+    </Target>
+</Project>

--- a/test/testData/SymbolFactoryTests/targetWithProperty.targets
+++ b/test/testData/SymbolFactoryTests/targetWithProperty.targets
@@ -1,0 +1,7 @@
+<Project>
+    <Target Name="TestTarget">
+        <PropertyGroup>
+            <TargetProperty>testvalue</TargetProperty>
+        </PropertyGroup>
+    </Target>
+</Project>


### PR DESCRIPTION
Implement initial target deserialization and symbol creation. The implementation includes support for properties and no other child elements (ex. tasks). When responding to document symbol requests, the property reference on the target is only provided if there isn't a property at the project-level with the same name due to how MSBuild processes files (properties before targets and nested elements). If the target is redefined in the same file (for some reason), only the first occurrence of the target is provided in the response. Similarly, the first target (by line number) to declare a property will define its symbol location.